### PR TITLE
Extract date time definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
 
+# Next version
+Features:
+- Added a DateTimeDefinition which represents the date / time part of cronjob lines. [PR #1](https://github.com/mintware-de/native-cron/pull/1)
+
+Deprecated:
+- `CronJobLine::getMinutes()` => `CronJobLine::getDateTimeDefinition()::getMinutes()`
+- `CronJobLine::getHours()` => `CronJobLine::getDateTimeDefinition()::getHours()`
+- `CronJobLine::getDays()` => `CronJobLine::getDateTimeDefinition()::getDays()`
+- `CronJobLine::getMonths()` => `CronJobLine::getDateTimeDefinition()::getMonths()`
+- `CronJobLine::getWeekdays()` => `CronJobLine::getDateTimeDefinition()::getWeekdays()`
+
 # v1.0.0
 Initial release

--- a/src/Content/DateTimeDefinition.php
+++ b/src/Content/DateTimeDefinition.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MintwareDe\NativeCron\Content;
+
+class DateTimeDefinition
+{
+    public const PATTERN = '(?P<minute>[\d\-,\*\/]+)\s*(?P<hour>[\d\-,\*\/]+)\s*(?P<day>[\d\-,\*\/]+)\s*(?P<month>[\d\-,\*\/]+)\s*(?P<weekday>[\d\-,\*\/]+)';
+
+    /** @var DateTimeField[] */
+    private array $minutes = [];
+
+    /** @var DateTimeField[] */
+    private array $hours = [];
+
+    /** @var DateTimeField[] */
+    private array $days = [];
+
+    /** @var DateTimeField[] */
+    private array $months = [];
+
+    /** @var DateTimeField[] */
+    private array $weekdays = [];
+
+    public function __construct()
+    {
+        $this->parse('* * * * *');
+    }
+
+    public function setMinutes(string $minutes): self
+    {
+        $this->minutes = $this->parseDateTimeField($minutes, 0, 59);
+
+        return $this;
+    }
+
+    public function setHours(string $hours): self
+    {
+        $this->hours = $this->parseDateTimeField($hours, 0, 23);
+
+        return $this;
+    }
+
+    public function setDays(string $days): self
+    {
+        $this->days = $this->parseDateTimeField($days, 1, 31);
+
+        return $this;
+    }
+
+    public function setMonths(string $months): self
+    {
+        $this->months = $this->parseDateTimeField($months, 1, 12);
+
+        return $this;
+    }
+
+    public function setWeekdays(string $weekdays): self
+    {
+        $this->weekdays = $this->parseDateTimeField($weekdays, 0, 6);
+
+        return $this;
+    }
+
+    /**
+     * @return DateTimeField[]
+     */
+    public function getMinutes(): array
+    {
+        return $this->minutes;
+    }
+
+    /**
+     * @return DateTimeField[]
+     */
+    public function getHours(): array
+    {
+        return $this->hours;
+    }
+
+    /**
+     * @return DateTimeField[]
+     */
+    public function getDays(): array
+    {
+        return $this->days;
+    }
+
+    /**
+     * @return DateTimeField[]
+     */
+    public function getMonths(): array
+    {
+        return $this->months;
+    }
+
+    /**
+     * @return DateTimeField[]
+     */
+    public function getWeekdays(): array
+    {
+        return $this->weekdays;
+    }
+
+    /**
+     * @return DateTimeField[]
+     */
+    private function parseDateTimeField(string $fieldString, int $min, int $max): array
+    {
+        $fields = [];
+        $entries = explode(',', $fieldString);
+        foreach ($entries as $entry) {
+            $field = new DateTimeField($min, $max);
+            $field->parse($entry);
+            $fields[] = $field;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Parses the string representation.
+     * Example values:
+     * - *   *      * * *
+     * - 0   0      1 1 0
+     * - 1-2 1-12/2 * * *
+     */
+    public function parse(string $string): void
+    {
+        if (!preg_match('~'.self::PATTERN.'~', $string, $matches)) {
+            throw new \RuntimeException('The date time definition string does not match the expected format.');
+        }
+
+        $this
+            ->setMinutes($matches['minute'])
+            ->setHours($matches['hour'])
+            ->setDays($matches['day'])
+            ->setMonths($matches['month'])
+            ->setWeekdays($matches['weekday']);
+    }
+
+    /**
+     * Converts this object to the string representation.
+     */
+    public function build(): string
+    {
+        $parts = [
+            implode(',', array_map(fn (DateTimeField $o) => $o->build(), $this->minutes)),
+            implode(',', array_map(fn (DateTimeField $o) => $o->build(), $this->hours)),
+            implode(',', array_map(fn (DateTimeField $o) => $o->build(), $this->days)),
+            implode(',', array_map(fn (DateTimeField $o) => $o->build(), $this->months)),
+            implode(',', array_map(fn (DateTimeField $o) => $o->build(), $this->weekdays)),
+        ];
+
+        return implode(' ', $parts);
+    }
+}

--- a/tests/Content/CronjobLineTest.php
+++ b/tests/Content/CronjobLineTest.php
@@ -65,39 +65,40 @@ class CronjobLineTest extends TestCase
 
         self::assertEquals('test arg', $cronjobLine->getCommand());
 
-        self::assertCount(1, $cronjobLine->getMinutes());
-        $minute = $cronjobLine->getMinutes()[0];
+        $dateTimeDefinition = $cronjobLine->getDateTimeDefinition();
+        self::assertCount(1, $dateTimeDefinition->getMinutes());
+        $minute = $dateTimeDefinition->getMinutes()[0];
         self::assertTrue($minute->hasValue());
         self::assertFalse($minute->isRange());
         self::assertEquals(0, $minute->getValueFrom());
         self::assertEquals(1, $minute->getStep());
 
-        self::assertCount(1, $cronjobLine->getHours());
-        $hours = $cronjobLine->getHours()[0];
+        self::assertCount(1, $dateTimeDefinition->getHours());
+        $hours = $dateTimeDefinition->getHours()[0];
         self::assertFalse($hours->hasValue());
         self::assertEquals(12, $hours->getStep());
 
-        self::assertCount(3, $cronjobLine->getDays());
-        $firstDay = $cronjobLine->getDays()[0];
+        self::assertCount(3, $dateTimeDefinition->getDays());
+        $firstDay = $dateTimeDefinition->getDays()[0];
         self::assertTrue($firstDay->hasValue());
         self::assertFalse($firstDay->isRange());
         self::assertEquals(1, $firstDay->getValueFrom());
         self::assertEquals(1, $firstDay->getStep());
 
-        $secondDay = $cronjobLine->getDays()[1];
+        $secondDay = $dateTimeDefinition->getDays()[1];
         self::assertTrue($secondDay->hasValue());
         self::assertTrue($secondDay->isRange());
         self::assertEquals(3, $secondDay->getValueFrom());
         self::assertEquals(5, $secondDay->getValueTo());
         self::assertEquals(1, $secondDay->getStep());
 
-        $thirdDay = $cronjobLine->getDays()[2];
+        $thirdDay = $dateTimeDefinition->getDays()[2];
         self::assertFalse($thirdDay->hasValue());
         self::assertTrue($thirdDay->isRange());
         self::assertEquals(5, $thirdDay->getStep());
 
-        self::assertCount(1, $cronjobLine->getMonths());
-        $month = $cronjobLine->getMonths()[0];
+        self::assertCount(1, $dateTimeDefinition->getMonths());
+        $month = $dateTimeDefinition->getMonths()[0];
         self::assertTrue($month->hasValue());
         self::assertTrue($month->isRange());
         self::assertEquals(4, $month->getValueFrom());
@@ -133,32 +134,33 @@ class CronjobLineTest extends TestCase
 
     private function checkEmptyValues(CronJobLine $cronjobLine): void
     {
-        self::assertCount(1, $cronjobLine->getMinutes());
-        $minute = $cronjobLine->getMinutes()[0];
+        $dateTimeDefinition = $cronjobLine->getDateTimeDefinition();
+        self::assertCount(1, $dateTimeDefinition->getMinutes());
+        $minute = $dateTimeDefinition->getMinutes()[0];
         self::assertFalse($minute->hasValue());
         self::assertEquals(0, $minute->getMin());
         self::assertEquals(59, $minute->getMax());
 
-        self::assertCount(1, $cronjobLine->getHours());
-        $hours = $cronjobLine->getHours()[0];
+        self::assertCount(1, $dateTimeDefinition->getHours());
+        $hours = $dateTimeDefinition->getHours()[0];
         self::assertFalse($hours->hasValue());
         self::assertEquals(0, $hours->getMin());
         self::assertEquals(23, $hours->getMax());
 
-        self::assertCount(1, $cronjobLine->getDays());
-        $days = $cronjobLine->getDays()[0];
+        self::assertCount(1, $dateTimeDefinition->getDays());
+        $days = $dateTimeDefinition->getDays()[0];
         self::assertFalse($days->hasValue());
         self::assertEquals(1, $days->getMin());
         self::assertEquals(31, $days->getMax());
 
-        self::assertCount(1, $cronjobLine->getMonths());
-        $month = $cronjobLine->getMonths()[0];
+        self::assertCount(1, $dateTimeDefinition->getMonths());
+        $month = $dateTimeDefinition->getMonths()[0];
         self::assertFalse($month->hasValue());
         self::assertEquals(1, $month->getMin());
         self::assertEquals(12, $month->getMax());
 
-        self::assertCount(1, $cronjobLine->getWeekdays());
-        $weekdays = $cronjobLine->getWeekdays()[0];
+        self::assertCount(1, $dateTimeDefinition->getWeekdays());
+        $weekdays = $dateTimeDefinition->getWeekdays()[0];
         self::assertFalse($weekdays->hasValue());
         self::assertEquals(0, $weekdays->getMin());
         self::assertEquals(6, $weekdays->getMax());

--- a/tests/Content/DateTimeDefinitionTest.php
+++ b/tests/Content/DateTimeDefinitionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MintwareDe\NativeCron\Tests\Content;
+
+use MintwareDe\NativeCron\Content\DateTimeDefinition;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeDefinitionTest extends TestCase
+{
+    public function testExists(): void
+    {
+        $definition = new DateTimeDefinition();
+
+        self::assertCount(1, $definition->getMinutes());
+        $minute = $definition->getMinutes()[0];
+        self::assertFalse($minute->hasValue());
+        self::assertEquals(0, $minute->getMin());
+        self::assertEquals(59, $minute->getMax());
+
+        self::assertCount(1, $definition->getHours());
+        $hours = $definition->getHours()[0];
+        self::assertFalse($hours->hasValue());
+        self::assertEquals(0, $hours->getMin());
+        self::assertEquals(23, $hours->getMax());
+
+        self::assertCount(1, $definition->getDays());
+        $days = $definition->getDays()[0];
+        self::assertFalse($days->hasValue());
+        self::assertEquals(1, $days->getMin());
+        self::assertEquals(31, $days->getMax());
+
+        self::assertCount(1, $definition->getMonths());
+        $month = $definition->getMonths()[0];
+        self::assertFalse($month->hasValue());
+        self::assertEquals(1, $month->getMin());
+        self::assertEquals(12, $month->getMax());
+
+        self::assertCount(1, $definition->getWeekdays());
+        $weekdays = $definition->getWeekdays()[0];
+        self::assertFalse($weekdays->hasValue());
+        self::assertEquals(0, $weekdays->getMin());
+        self::assertEquals(6, $weekdays->getMax());
+    }
+
+    public function testSetters(): void
+    {
+        $definition = new DateTimeDefinition();
+        $definition
+            ->setMinutes('1,2')
+            ->setHours('3,4')
+            ->setDays('5,6')
+            ->setMonths('7-8')
+            ->setWeekdays('1,3,5,0-5/2,6')
+        ;
+        self::assertEquals('1,2 3,4 5,6 7-8 1,3,5,0-5/2,6', $definition->build());
+
+    }
+
+    public function testParseFailsInvalidFormat(): void
+    {
+        $definition = new DateTimeDefinition();
+
+        self::expectException(\RuntimeException::class);
+        self::expectExceptionMessage('The date time definition string does not match the expected format.');
+
+        $definition->parse("test");
+    }
+
+    public function testParse(): void
+    {
+        $definition = new DateTimeDefinition();
+        $definition->parse("0 */12 1,3-5,*/5 4-8 *");
+
+        self::assertCount(1, $definition->getMinutes());
+        $minute = $definition->getMinutes()[0];
+        self::assertTrue($minute->hasValue());
+        self::assertFalse($minute->isRange());
+        self::assertEquals(0, $minute->getValueFrom());
+        self::assertEquals(1, $minute->getStep());
+
+        self::assertCount(1, $definition->getHours());
+        $hours = $definition->getHours()[0];
+        self::assertFalse($hours->hasValue());
+        self::assertEquals(12, $hours->getStep());
+
+        self::assertCount(3, $definition->getDays());
+        $firstDay = $definition->getDays()[0];
+        self::assertTrue($firstDay->hasValue());
+        self::assertFalse($firstDay->isRange());
+        self::assertEquals(1, $firstDay->getValueFrom());
+        self::assertEquals(1, $firstDay->getStep());
+
+        $secondDay = $definition->getDays()[1];
+        self::assertTrue($secondDay->hasValue());
+        self::assertTrue($secondDay->isRange());
+        self::assertEquals(3, $secondDay->getValueFrom());
+        self::assertEquals(5, $secondDay->getValueTo());
+        self::assertEquals(1, $secondDay->getStep());
+
+        $thirdDay = $definition->getDays()[2];
+        self::assertFalse($thirdDay->hasValue());
+        self::assertTrue($thirdDay->isRange());
+        self::assertEquals(5, $thirdDay->getStep());
+
+        self::assertCount(1, $definition->getMonths());
+        $month = $definition->getMonths()[0];
+        self::assertTrue($month->hasValue());
+        self::assertTrue($month->isRange());
+        self::assertEquals(4, $month->getValueFrom());
+        self::assertEquals(8, $month->getValueTo());
+    }
+
+    public function testParseBuild(): void
+    {
+        $tests = [
+            '* * * * *',
+            '0 0 1 1 0',
+            '1-2 1-12/2 * * *',
+        ];
+
+        foreach ($tests as $test) {
+            $definition = new DateTimeDefinition();
+            $definition->parse($test);
+            self::assertEquals($test, $definition->build());
+        }
+    }
+}

--- a/tests/Content/DateTimeDefinitionTest.php
+++ b/tests/Content/DateTimeDefinitionTest.php
@@ -55,7 +55,6 @@ class DateTimeDefinitionTest extends TestCase
             ->setWeekdays('1,3,5,0-5/2,6')
         ;
         self::assertEquals('1,2 3,4 5,6 7-8 1,3,5,0-5/2,6', $definition->build());
-
     }
 
     public function testParseFailsInvalidFormat(): void


### PR DESCRIPTION
Features:
- Added a DateTimeDefinition which represents the date / time part of cronjob lines.

Deprecated:
- `CronJobLine::getMinutes()` => `CronJobLine::getDateTimeDefinition()::getMinutes()`
- `CronJobLine::getHours()` => `CronJobLine::getDateTimeDefinition()::getHours()`
- `CronJobLine::getDays()` => `CronJobLine::getDateTimeDefinition()::getDays()`
- `CronJobLine::getMonths()` => `CronJobLine::getDateTimeDefinition()::getMonths()`
- `CronJobLine::getWeekdays()` => `CronJobLine::getDateTimeDefinition()::getWeekdays()`