### PR TITLE
Crontabs must end with an empty line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v1.1.1
+Fixes:
+- Crontabs must end with an empty line [PR #2](https://github.com/mintware-de/native-cron/pull/2)
+
 # v1.1.0
 Features:
 - Added a DateTimeDefinition which represents the date / time part of cronjob lines. [PR #1](https://github.com/mintware-de/native-cron/pull/1)

--- a/src/Content/Crontab.php
+++ b/src/Content/Crontab.php
@@ -113,6 +113,11 @@ class Crontab
 
     public function build(): string
     {
-        return implode("\n", array_map(fn (CrontabLineInterface $l) => $l->build(), $this->lines));
+        $content = implode("\n", array_map(fn (CrontabLineInterface $l) => $l->build(), $this->lines));
+        if (!str_ends_with($content, "\n")) {
+            $content .= "\n";
+        }
+
+        return $content;
     }
 }

--- a/tests/Content/CrontabTest.php
+++ b/tests/Content/CrontabTest.php
@@ -45,12 +45,13 @@ class CrontabTest extends TestCase
 # Edit this file to introduce tasks to be run by cron.
 
 */2 * * * * test argument
+
 TEXT;
 
         $crontab = new Crontab(false);
         $crontab->parse($content);
         $lines = $crontab->getLines();
-        self::assertCount(3, $lines);
+        self::assertCount(4, $lines);
         self::assertInstanceOf(CommentLine::class, $lines[0]);
         self::assertInstanceOf(BlankLine::class, $lines[1]);
         self::assertInstanceOf(CronJobLine::class, $lines[2]);
@@ -78,6 +79,7 @@ TEXT;
 # Edit this file to introduce tasks to be run by cron.
 
 */2 * * * * test argument
+
 TEXT;
         self::assertEquals($expected, $crontab->build());
     }
@@ -88,12 +90,13 @@ TEXT;
 # Edit this file to introduce tasks to be run by cron.
 
 */2 * * * * root test argument
+
 TEXT;
 
         $crontab = new Crontab();
         $crontab->parse($content);
         $lines = $crontab->getLines();
-        self::assertCount(3, $lines);
+        self::assertCount(4, $lines);
         self::assertInstanceOf(CommentLine::class, $lines[0]);
         self::assertInstanceOf(BlankLine::class, $lines[1]);
         self::assertInstanceOf(CronJobLine::class, $lines[2]);
@@ -124,6 +127,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 52 6	1 * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
 52 6	1 * *	root	test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
 #
+
 TEXT;
 
         $crontab = new Crontab();
@@ -137,6 +141,7 @@ TEXT;
 # Edit this file to introduce tasks to be run by cron.
 
 */2 * * * * test argument
+
 TEXT;
 
         $crontab = new Crontab(false);
@@ -153,6 +158,7 @@ TEXT;
         $content = <<<TEXT
 # Edit this file to introduce tasks to be run by cron.
 */2 * * * * test argument
+
 TEXT;
 
         $crontab = new Crontab(false);
@@ -171,6 +177,7 @@ TEXT;
         $content = <<<TEXT
 # Edit this file to introduce tasks to be run by cron.
 */2 * * * * test argument
+
 TEXT;
 
         $crontab = new Crontab(false);
@@ -187,5 +194,11 @@ TEXT;
             ->removeWhere(fn (CrontabLineInterface $line) => $line instanceof BlankLine);
 
         self::assertEquals($content, $crontab->build());
+    }
+
+    public function testBuildShouldAppendABlankLine(): void
+    {
+        $crontab = new Crontab();
+        self::assertEquals("\n", $crontab->build());
     }
 }


### PR DESCRIPTION
Add a empty line to the crontab when it's not present