### PR TITLE
Fix user detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v1.1.2
+Fixes:
+- Usernames can contain `\W` characters [PR #3](https://github.com/mintware-de/native-cron/pull/3)
+
 # v1.1.1
 Fixes:
 - Crontabs must end with an empty line [PR #2](https://github.com/mintware-de/native-cron/pull/2)

--- a/src/Content/CronJobLine.php
+++ b/src/Content/CronJobLine.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 class CronJobLine implements CrontabLineInterface
 {
-    public const PATTERN_WITH_USER = '~^(?P<datetime>'.DateTimeDefinition::PATTERN.')\s*(?P<user>\w+)\s*(?P<command>.+)$~';
+    public const PATTERN_WITH_USER = '~^(?P<datetime>'.DateTimeDefinition::PATTERN.')\s*(?P<user>[^\s]+)\s*(?P<command>.+)$~';
     public const PATTERN_WITHOUT_USER = '~^(?P<datetime>'.DateTimeDefinition::PATTERN.')\s*(?P<command>.+)$~';
 
     private bool $includeUser;

--- a/tests/Content/CronjobLineTest.php
+++ b/tests/Content/CronjobLineTest.php
@@ -132,6 +132,13 @@ class CronjobLineTest extends TestCase
         self::assertEquals($line, $cronjobLine->build());
     }
 
+    public function testUserWithDashes(): void
+    {
+        $line = '* * * * * www-data command';
+        $cronjobLine = new CronJobLine($line, true);
+        self::assertEquals('www-data', $cronjobLine->getUser());
+    }
+
     private function checkEmptyValues(CronJobLine $cronjobLine): void
     {
         $dateTimeDefinition = $cronjobLine->getDateTimeDefinition();


### PR DESCRIPTION
Usernames can contain `\W` characters such as `-` or `_`.