### PR TITLE
Add support for abbreviation values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Next version
+Features
+- Added support for month and weekday abbreviations [PR #4](https://github.com/mintware-de/native-cron/pull/4)
+
 # v1.1.2
 Fixes:
 - Usernames can contain `\W` characters [PR #3](https://github.com/mintware-de/native-cron/pull/3)

--- a/src/Content/DateTimeDefinition.php
+++ b/src/Content/DateTimeDefinition.php
@@ -6,7 +6,23 @@ namespace MintwareDe\NativeCron\Content;
 
 class DateTimeDefinition
 {
-    public const PATTERN = '(?P<minute>[\d\-,\*\/]+)\s*(?P<hour>[\d\-,\*\/]+)\s*(?P<day>[\d\-,\*\/]+)\s*(?P<month>[\d\-,\*\/]+)\s*(?P<weekday>[\d\-,\*\/]+)';
+    public const PATTERN = '(?P<minute>[\d\-,\*\/]+)\s*(?P<hour>[\d\-,\*\/]+)\s*(?P<day>[\d\-,\*\/]+)\s*(?P<month>[\d\w\-,\*\/]+)\s*(?P<weekday>[\d\-,\*\/]+)';
+
+    /** @var array<string, int> */
+    public const MONTH_ABBREVIATIONS = [
+        'jan' => 1,
+        'feb' => 2,
+        'mar' => 3,
+        'apr' => 4,
+        'may' => 5,
+        'jun' => 6,
+        'jul' => 7,
+        'aug' => 8,
+        'sep' => 9,
+        'oct' => 10,
+        'nov' => 11,
+        'dec' => 12,
+    ];
 
     /** @var DateTimeField[] */
     private array $minutes = [];
@@ -51,7 +67,7 @@ class DateTimeDefinition
 
     public function setMonths(string $months): self
     {
-        $this->months = $this->parseDateTimeField($months, 1, 12);
+        $this->months = $this->parseDateTimeField($months, 1, 12, self::MONTH_ABBREVIATIONS);
 
         return $this;
     }
@@ -104,14 +120,16 @@ class DateTimeDefinition
     }
 
     /**
+     * @param array<string, mixed> $abbreviations Values for abbreviations such as jan,feb or mon-fri.
+     *
      * @return DateTimeField[]
      */
-    private function parseDateTimeField(string $fieldString, int $min, int $max): array
+    private function parseDateTimeField(string $fieldString, int $min, int $max, array $abbreviations = []): array
     {
         $fields = [];
         $entries = explode(',', $fieldString);
         foreach ($entries as $entry) {
-            $field = new DateTimeField($min, $max);
+            $field = new DateTimeField($min, $max, $abbreviations);
             $field->parse($entry);
             $fields[] = $field;
         }

--- a/src/Content/DateTimeDefinition.php
+++ b/src/Content/DateTimeDefinition.php
@@ -6,7 +6,7 @@ namespace MintwareDe\NativeCron\Content;
 
 class DateTimeDefinition
 {
-    public const PATTERN = '(?P<minute>[\d\-,\*\/]+)\s*(?P<hour>[\d\-,\*\/]+)\s*(?P<day>[\d\-,\*\/]+)\s*(?P<month>[\d\w\-,\*\/]+)\s*(?P<weekday>[\d\-,\*\/]+)';
+    public const PATTERN = '(?P<minute>[\d\-,\*\/]+)\s*(?P<hour>[\d\-,\*\/]+)\s*(?P<day>[\d\-,\*\/]+)\s*(?P<month>[\d\w\-,\*\/]+)\s*(?P<weekday>[\d\w\-,\*\/]+)';
 
     /** @var array<string, int> */
     public const MONTH_ABBREVIATIONS = [
@@ -22,6 +22,17 @@ class DateTimeDefinition
         'oct' => 10,
         'nov' => 11,
         'dec' => 12,
+    ];
+
+    /** @var array<string, int> */
+    public const WEEKDAY_ABBREVIATIONS = [
+        'sun' => 0,
+        'mon' => 1,
+        'tue' => 2,
+        'wed' => 3,
+        'thu' => 4,
+        'fri' => 5,
+        'sat' => 6,
     ];
 
     /** @var DateTimeField[] */
@@ -74,7 +85,7 @@ class DateTimeDefinition
 
     public function setWeekdays(string $weekdays): self
     {
-        $this->weekdays = $this->parseDateTimeField($weekdays, 0, 6);
+        $this->weekdays = $this->parseDateTimeField($weekdays, 0, 6, self::WEEKDAY_ABBREVIATIONS);
 
         return $this;
     }

--- a/src/Content/DateTimeField.php
+++ b/src/Content/DateTimeField.php
@@ -12,9 +12,15 @@ class DateTimeField
     private int $valueTo;
     private int $step = 1;
 
+    /**
+     * @param int                  $min
+     * @param int                  $max
+     * @param array<string, mixed> $abbreviations Values for abbreviations such as jan,feb or mon-fri.
+     */
     public function __construct(
         private readonly int $min,
         private readonly int $max,
+        private readonly array $abbreviations = [],
     ) {
         $this->valueFrom = $min;
         $this->valueTo = $max;
@@ -160,10 +166,19 @@ class DateTimeField
             $string .= '/1';
         }
         [$value, $step] = explode('/', $string, 2);
+        if (array_key_exists($value, $this->abbreviations)) {
+            $value = strval($this->abbreviations[$value]);
+        }
         if ($value == '*') {
             $this->unsetValue();
         } elseif (str_contains($value, '-')) {
-            [$from, $to] = array_map('intval', explode('-', $value, 2));
+            [$from, $to] = array_map(function ($part) {
+                if (array_key_exists($part, $this->abbreviations)) {
+                    $part = $this->abbreviations[$part];
+                }
+
+                return intval($part);
+            }, explode('-', $value, 2));
             $this->setRangeValue($from, $to);
         } elseif (is_numeric($value)) {
             $this->setValue(intval($value));

--- a/tests/Content/CronjobLineTest.php
+++ b/tests/Content/CronjobLineTest.php
@@ -146,6 +146,13 @@ class CronjobLineTest extends TestCase
         self::assertEquals(1, $cronjobLine->getDateTimeDefinition()->getMonths()[0]->getValueFrom());
     }
 
+    public function testWeekdayAbbreviations(): void
+    {
+        $line = '* * * * fri www-data command';
+        $cronjobLine = new CronJobLine($line, true);
+        self::assertEquals(5, $cronjobLine->getDateTimeDefinition()->getWeekdays()[0]->getValueFrom());
+    }
+
     private function checkEmptyValues(CronJobLine $cronjobLine): void
     {
         $dateTimeDefinition = $cronjobLine->getDateTimeDefinition();

--- a/tests/Content/CronjobLineTest.php
+++ b/tests/Content/CronjobLineTest.php
@@ -139,6 +139,13 @@ class CronjobLineTest extends TestCase
         self::assertEquals('www-data', $cronjobLine->getUser());
     }
 
+    public function testMonthAbbreviations(): void
+    {
+        $line = '* * * jan * www-data command';
+        $cronjobLine = new CronJobLine($line, true);
+        self::assertEquals(1, $cronjobLine->getDateTimeDefinition()->getMonths()[0]->getValueFrom());
+    }
+
     private function checkEmptyValues(CronJobLine $cronjobLine): void
     {
         $dateTimeDefinition = $cronjobLine->getDateTimeDefinition();

--- a/tests/Content/DateTimeFieldTest.php
+++ b/tests/Content/DateTimeFieldTest.php
@@ -168,4 +168,25 @@ class DateTimeFieldTest extends TestCase
         self::assertEquals(12, $monthField->getValueTo());
         self::assertEquals(2, $monthField->getStep());
     }
+
+    public function testParseWithAbbreviationsValues(): void
+    {
+        $monthField = new DateTimeField(1, 12, [
+            'jan' => 1,
+            'feb' => '2',
+            'mar' => '3',
+            'apr' => 4,
+        ]);
+        self::assertFalse($monthField->hasValue());
+
+        $monthField->parse('jan-apr/2');
+        self::assertEquals(1, $monthField->getValueFrom());
+        self::assertEquals(4, $monthField->getValueTo());
+        self::assertEquals(2, $monthField->getStep());
+
+        $monthField->parse('jan');
+        self::assertEquals(1, $monthField->getValueFrom());
+        self::assertEquals(1, $monthField->getValueTo());
+        self::assertEquals(1, $monthField->getStep());
+    }
 }


### PR DESCRIPTION
A crontab may contain a alternative syntax for month and weekday values:
https://man7.org/linux/man-pages/man5/crontab.5.html#EXAMPLE_CRON_FILE

This PR will add support for abbreviations

- Updated DateTimeDefinition pattern to allow word-characters in the month field
- Added the DateTimeDefinition::MONTH_ABBREVIATIONS constant for months abbrevations.
- Added the $abbreviations Parameter to DateTimeDefinition::parseDateTimeField which will be passed to the DateTimeField constructor
- Updated DateTimeDefinition::setMonths and pass the months abbreviations as $abbreviations to DateTimeDefinition::parseDateTimeField
- Added the $abbreviations parameter to the DateTimeField constructor
- Updated DateTimeField::parse for handling abbreviations.
- Added the DateTimeDefinition::WEEKDAY_ABBREVIATIONS constant for weekday abbreviations.
- Updated DateTimeDefinition::setWeekdays and pass the weekday abbreviations as $abbreviations to DateTimeDefinition::parseDateTimeField
